### PR TITLE
Improve tooltip readability and icon hover

### DIFF
--- a/packages/web/src/app/(authenticated)/dashboard/inbox/page.tsx
+++ b/packages/web/src/app/(authenticated)/dashboard/inbox/page.tsx
@@ -849,7 +849,7 @@ export default function InboxPage() {
                           </TooltipTrigger>
                           <TooltipContent side="bottom">
                             <p className="font-medium mb-1">Force Sync</p>
-                            <p className="text-xs text-muted-foreground">
+                            <p className="text-xs text-primary-foreground">
                               Manually check for new emails
                             </p>
                           </TooltipContent>
@@ -864,17 +864,17 @@ export default function InboxPage() {
                           <Button
                             variant="ghost"
                             size="icon"
-                            className="h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                            className="h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-100"
                             onClick={() =>
                               router.push('/dashboard/settings/integrations')
                             }
                           >
-                            <Settings className="h-3.5 w-3.5" />
+                            <Settings className="h-3.5 w-3.5 text-inherit" />
                           </Button>
                         </TooltipTrigger>
                         <TooltipContent side="bottom">
                           <p className="font-medium mb-1">Integration Settings</p>
-                          <p className="text-xs text-muted-foreground">
+                          <p className="text-xs text-primary-foreground">
                             Manage keywords, filters, and AI rules
                           </p>
                         </TooltipContent>

--- a/packages/web/src/components/inbox-card.tsx
+++ b/packages/web/src/components/inbox-card.tsx
@@ -881,7 +881,7 @@ export function InboxCard({ card, onClick }: InboxCardProps) {
                             ))}
                           </ul>
                           {card.appliedClassifications?.some(c => c.confidence && c.confidence < 70) && (
-                            <p className="text-xs text-muted-foreground mt-2 pt-2 border-t">
+                            <p className="text-xs text-primary-foreground mt-2 pt-2 border-t">
                               <AlertCircle className="h-3 w-3 inline mr-1" />
                               Rules with confidence below 70% may need review
                             </p>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhance readability of tooltip subtitles and ensure consistent cog icon color on hover.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, tooltip subtitles were difficult to read due to low contrast, and the cog icon in the inbox page turned white on hover, which was visually inconsistent.