### PR TITLE
fix: KYC authentication redirect and in-progress state handling

### DIFF
--- a/packages/web/src/app/(authenticated)/dashboard/(bank)/components/dashboard/onboarding-tasks-card.tsx
+++ b/packages/web/src/app/(authenticated)/dashboard/(bank)/components/dashboard/onboarding-tasks-card.tsx
@@ -66,6 +66,7 @@ export function OnboardingTasksCard({ initialData }: OnboardingTasksProps) {
   const isKycComplete = kycStep?.isCompleted ?? false;
   const kycStatus = kycStep?.status;
   const kycMarkedDone = kycStep?.kycMarkedDone ?? false;
+  const kycSubStatus = kycStep?.kycSubStatus;
 
   // If KYC is complete, don't show the card
   if (isKycComplete) return null;
@@ -88,9 +89,8 @@ export function OnboardingTasksCard({ initialData }: OnboardingTasksProps) {
       ),
     };
   } else if (
-    kycStatus === 'pending' ||
-    kycStep?.kycSubStatus === 'kyc_form_submission_accepted' ||
-    kycMarkedDone
+    kycStatus === 'pending' &&
+    (kycMarkedDone || kycSubStatus === 'kyc_form_submission_accepted')
   ) {
     kycContent = {
       icon: <Loader2 className="h-6 w-6 animate-spin text-[#0050ff]" />,
@@ -98,6 +98,18 @@ export function OnboardingTasksCard({ initialData }: OnboardingTasksProps) {
       description:
         'Your verification is being reviewed. This usually takes a few minutes.',
       button: null,
+    };
+  } else if (kycStatus === 'pending') {
+    kycContent = {
+      icon: <Circle className="h-6 w-6 text-[#0050ff]" />,
+      title: 'Continue Identity Verification',
+      description:
+        "You started verification but haven't finished. Continue where you left off.",
+      button: (
+        <Button asChild className="w-full">
+          <Link href="/onboarding/kyc">Continue Verification</Link>
+        </Button>
+      ),
     };
   } else {
     kycContent = {

--- a/packages/web/src/app/onboarding/kyc/page.tsx
+++ b/packages/web/src/app/onboarding/kyc/page.tsx
@@ -16,6 +16,7 @@ import { ArrowLeft } from 'lucide-react';
 import { AlignKycStatus } from '@/components/settings/align-integration';
 import { steps as onboardingSteps } from '../constants';
 import { useSkipOnboarding } from '@/hooks/use-skip-onboarding';
+import { usePrivy } from '@privy-io/react-auth';
 
 const completeOnboardingStep = (step: string) => {
   if (typeof window !== 'undefined') {
@@ -25,8 +26,15 @@ const completeOnboardingStep = (step: string) => {
 
 export default function KycOnboardingPage() {
   const router = useRouter();
+  const { ready, authenticated } = usePrivy();
   const { skipOnboarding, isSkipping } = useSkipOnboarding();
   const [kycApproved, setKycApproved] = React.useState(false);
+
+  React.useEffect(() => {
+    if (ready && !authenticated) {
+      router.push('/signin');
+    }
+  }, [ready, authenticated, router]);
 
   const handleKycApproved = () => {
     console.log('KYC Approved! User can now continue manually.');


### PR DESCRIPTION
## Summary
- Fixes unauthenticated user access to /onboarding/kyc by redirecting to /signin instead of showing error messages
- Adds Continue Verification button for users who started KYC but didn't finish, resolving a stuck state issue